### PR TITLE
fix: correct batch counting and squeeze dim in prott5_embedder.py

### DIFF
--- a/Embedding/prott5_embedder.py
+++ b/Embedding/prott5_embedder.py
@@ -97,7 +97,7 @@ def get_embeddings( seq_path,
 
         # count residues in current batch and add the last sequence length to
         # avoid that batches with (n_res_batch > max_residues) get processed 
-        n_res_batch = sum([ s_len for  _, _, s_len in batch ]) + seq_len 
+        n_res_batch = sum([ s_len for  _, _, s_len in batch ])
         if len(batch) >= max_batch or n_res_batch>=max_residues or seq_idx==len(seq_dict) or seq_len>max_seq_len:
             pdb_ids, seqs, seq_lens = zip(*batch)
             batch = list()
@@ -128,7 +128,7 @@ def get_embeddings( seq_path,
                     print("Embedded protein {} with length {} to emb. of shape: {}".format(
                         identifier, s_len, emb.shape))
 
-                emb_dict[ identifier ] = emb.detach().cpu().numpy().squeeze()
+                emb_dict[ identifier ] = emb.detach().cpu().numpy().squeeze(0)
 
     end = time.time()
     


### PR DESCRIPTION
## Summary

Two bugs in `Embedding/prott5_embedder.py`:

- **Double-counting in batch residue accumulation** (line 100): The current sequence is appended to `batch` *before* computing `n_res_batch`, so `seq_len` is counted once inside the `sum()` over the batch and again via the explicit `+ seq_len`. This causes batches to trigger the `n_res_batch >= max_residues` threshold too early, resulting in smaller batches than intended and slower embedding.

- **Bare `.squeeze()` without dim** (line 131): For single-residue proteins in per-residue mode, the embedding shape `(1, 1024)` is silently collapsed to `(1024,)`, making it indistinguishable from a per-protein embedding. Changed to `.squeeze(0)` to only affect the batch dimension.

## Test plan

- [ ] Verified the double-counting by tracing the logic: after `batch.append(...)`, the batch already contains the current sequence, so the separate `+ seq_len` is redundant
- [ ] `.squeeze(0)` is a no-op when the first dimension is > 1, preserving existing behavior for all multi-residue proteins